### PR TITLE
Fix summary_df initialization in deseq_analysis function

### DIFF
--- a/R/rna_functions.R
+++ b/R/rna_functions.R
@@ -388,7 +388,7 @@ deseq_analysis <- function(dds, conditions, controls = NULL, outpath, ...) {
 
   # Initialize list to store results
   # analysis_list <- list()
-  # summary_df <- data.frame()
+  summary_df <- data.frame()
 
   # Use lapply to iterate through conditions
   analysis_list <- lapply(conditions, function(condition) {


### PR DESCRIPTION
Initialize the `summary_df` variable in the `deseq_analysis` function to ensure proper data frame creation.