### PR TITLE
Fix filtered hazard ratios and remove internal dependencies; version bump to 0.2.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rmatt
 Title: A Collection of R Tools
-Version: 0.2.2
+Version: 0.2.3
 Maintainer: Matthew Muller <mm12865@nyu.edu>
 Description: This package contains a collection of all the R tools I've made during my PhD. It covers mainly multiomic analyses, statistical methods, and data wrangling.
 Author: Matthew Muller


### PR DESCRIPTION
Correct the calculation of filtered hazard ratios and streamline the code by removing unnecessary dependencies. Update the package version to reflect these changes.